### PR TITLE
adding pcg_table to info service

### DIFF
--- a/annotationinfoservice/admin.py
+++ b/annotationinfoservice/admin.py
@@ -1,9 +1,10 @@
 from flask_admin import Admin
 from flask_admin.contrib.sqla import ModelView
-from annotationinfoservice.datasets.models import DataSet
+from annotationinfoservice.datasets.models import DataSet, PyChunkedGraphTable
 
 
 def setup_admin(app, db):
     admin = Admin(app, name="annotationinfoservice")
     admin.add_view(ModelView(DataSet, db.session))
+    admin.add_view(ModelView(PyChunkedGraphTable, db.session))
     return admin

--- a/annotationinfoservice/config.py
+++ b/annotationinfoservice/config.py
@@ -53,4 +53,6 @@ def configure_app(app):
     from .datasets.schemas import ma
     db.init_app(app)
     ma.init_app(app)
+    with app.app_context():
+        db.create_all()
     return app

--- a/annotationinfoservice/datasets/controllers.py
+++ b/annotationinfoservice/datasets/controllers.py
@@ -1,7 +1,7 @@
 # Import flask dependencies
 from flask import Blueprint, jsonify, render_template, current_app
-from annotationinfoservice.datasets.models import DataSet
-from annotationinfoservice.datasets.schemas import DataSetSchema
+from annotationinfoservice.datasets.models import DataSet, PyChunkedGraphTable
+from annotationinfoservice.datasets.schemas import DataSetSchema, PyChunkedGraphTableSchema
 import neuroglancer
 
 mod_datasets = Blueprint('datasets', __name__, url_prefix='/datasets')
@@ -45,3 +45,9 @@ def get_dataset(dataset):
     dataset = DataSet.query.filter_by(name=dataset).first_or_404()
     schema = DataSetSchema()
     return schema.jsonify(dataset)
+
+@mod_datasets.route("/api/pcg_table/<tablename>", methods=['GET'])
+def get_pcg_table(tablename):
+    table = PyChunkedGraphTable.query.filter_by(name=tablename).first_or_404()
+    schema = PyChunkedGraphTableSchema()
+    return schema.jsonify(table)

--- a/annotationinfoservice/datasets/models.py
+++ b/annotationinfoservice/datasets/models.py
@@ -1,10 +1,11 @@
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, ForeignKey
 from annotationinfoservice.database import Base
+from sqlalchemy.orm import relationship
 
 
 class NamedModel(object):
     id = Column(Integer, primary_key=True)
-    name = Column(String(100), nullable=False)
+    name = Column(String(100), nullable=False, unique=True)
 
     def __repr__(self):
         return "{}({})".format(self.name, self.id)
@@ -22,3 +23,9 @@ class DataSet(NamedModel, Base):
     graphene_source = Column(String(200), nullable=True)
     pychunkedgraph_supervoxel_source = Column(String(200), nullable=True)
     analysis_database_ip = Column(String(100), nullable=True)
+    pcg_tables = relationship("PyChunkedGraphTable")
+    
+class PyChunkedGraphTable(NamedModel, Base):
+    __tablename__ = "pcg_tables"
+    dataset_id = Column(Integer, ForeignKey('dataset.id'))
+    dataset =  relationship("DataSet", back_populates="pcg_tables")

--- a/annotationinfoservice/datasets/schemas.py
+++ b/annotationinfoservice/datasets/schemas.py
@@ -3,6 +3,24 @@ from flask_marshmallow import Marshmallow
 
 ma = Marshmallow()
 
+
+
+class SimpleDatasetSchema(ma.ModelSchema):
+    class Meta:
+        model = models.DataSet
+        fields = ['name','id']
+
+class PyChunkedGraphTableSchema(ma.ModelSchema):
+    dataset = ma.Nested(SimpleDatasetSchema)
+    class Meta:
+        model = models.PyChunkedGraphTable
+
+class SimplePyChunkedGraphTableSchema(ma.ModelSchema):
+    class Meta:
+        model = models.PyChunkedGraphTable
+        fields = ['name']
+
 class DataSetSchema(ma.ModelSchema):
+    pcg_tables = ma.Nested(SimplePyChunkedGraphTableSchema, many=True)
     class Meta:
         model = models.DataSet


### PR DESCRIPTION
This will give the info service the responsibility to track all the pcg tables and what datasets they belong to, freeing the pcg service to make tables willy nilly and the info service will help us map what goes with what.  importantly the pcg or auth service can use this information to map pcg table names to datasets, where the permissions will be attached. 