### PR TITLE
Add tourguide link to datastack info page if skeleton source is present.

### DIFF
--- a/annotationinfoservice/templates/datastack.html
+++ b/annotationinfoservice/templates/datastack.html
@@ -34,6 +34,13 @@
         Dash Apps</a>
     </td>
   </tr>
+  {% if datastack.skeleton_source is not none %}
+  <tr>
+    <td><a href="{{datastack.local_server}}/tourguide/app/datastack/{{datastack.name}}">
+        Tourguide</a>
+    </td>
+  </tr>
+  {% endif %}
   <tr>
     <td>
       <a href="/schema">


### PR DESCRIPTION
Add tourguide link to the datastack page if the skeleton service is defined